### PR TITLE
fixes bug with cli and closes #49

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sfdep
 Title: Spatial Dependence for Simple Features
-Version: 0.2.4
+Version: 0.2.4.9000
 Authors@R: c(
     person("Josiah", "Parry", , "josiah.parry@gmail.com", role = c("aut"),
            comment = c(ORCID = "0000-0001-9910-865X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sfdep (development version)
+
+- fixes bug with cli and closes #49
+
 # sfdep 0.2.4
 
 - Dexter Locke is now the maintainer of sfdep

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # sfdep (development version)
 
-- fixes bug with cli and closes #49
+- Fixes bug with cli and closes #49
 
 # sfdep 0.2.4
 

--- a/R/spacetime-constructor.R
+++ b/R/spacetime-constructor.R
@@ -176,8 +176,8 @@ validate_spacetime <- function(.data, .geometry, .loc_col, .time_col) {
   if (!identical(.data_loc_class, .geo_loc_class)) {
     cli::cli_abort(
       c("Differing class types for {.var .loc_col}.",
-        i = "{.var .data}:       {.cls {.data_loc_class}}",
-        "i" = "{.var .geometry}: {.cls {.geo_loc_class}}.")
+        i = "{.var .data}:       {.cls {(.data_loc_class)}}",
+        "i" = "{.var .geometry}: {.cls {(.geo_loc_class)}}.")
     )
   }
 

--- a/tests/testthat/test-spacetime-constructor_cli_update_patch.R
+++ b/tests/testthat/test-spacetime-constructor_cli_update_patch.R
@@ -1,0 +1,12 @@
+test_that("local_g_perm", {
+  df_fp <- system.file("extdata", "bos-ecometric.csv", package = "sfdep")
+  geo_fp <- system.file("extdata", "bos-ecometric.geojson", package = "sfdep")
+
+  # read in data
+  df <- read.csv(
+    df_fp, colClasses = c("numeric", "character", "integer", "double", "Date")
+  )
+
+  geo <- sf::st_read(geo_fp)
+  expect_error(spacetime(df, geo, ".region_id", "year"))
+})


### PR DESCRIPTION
a cli package update broke the styling associated with a cli command used to make a legible error message about type matching within the spacetime constructor #49 