### PR TITLE
set operations should sort neighbour indices

### DIFF
--- a/R/utils-set-operations.R
+++ b/R/utils-set-operations.R
@@ -23,6 +23,7 @@
 #' @export
 nb_union <- function(x, y) {
   res <- mapply(union, x, y, SIMPLIFY = FALSE)
+  res <- lapply(res, sort)
   res <- fill_missing_nb(res)
   class_modify(res, "nb")
 }
@@ -32,6 +33,7 @@ nb_union <- function(x, y) {
 #' @export
 nb_intersect <- function(x, y) {
   res <- mapply(intersect, x, y, SIMPLIFY = FALSE)
+  res <- lapply(res, sort)
   res <- fill_missing_nb(res)
   class_modify(res, "nb")
 }
@@ -40,6 +42,7 @@ nb_intersect <- function(x, y) {
 #' @export
 nb_setdiff <- function(x, y) {
   res <- mapply(setdiff, x, y, SIMPLIFY = FALSE)
+  res <- lapply(res, sort)
   res <- fill_missing_nb(res)
   class_modify(res, "nb")
 }


### PR DESCRIPTION
In my rev-dep checks, `nb_union` failed on `print` because the neighbour indices were not sorted in ascending order. In `print.nb`, `n.comp.nb` was run, and chose the `igraph` path, so needing coercion to a sparse matrix then a graph - coercion to a sparse matrix requires indices to be given in ascending order.