### PR TITLE
minor fixes to person() usage and typo in see also linkage to sf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,9 @@ Package: sfdep
 Title: Spatial Dependence for Simple Features
 Version: 0.2.4.9000
 Authors@R: c(
-    person("Josiah", "Parry", , "josiah.parry@gmail.com", role = c("aut"),
+    person("Josiah", "Parry", email = "josiah.parry@gmail.com", role = c("aut"),
            comment = c(ORCID = "0000-0001-9910-865X")),
-    person("Dexter", "Locke", 'H', "dexter.locke@gmail.com", role = c("aut", "cre"),
+    person("Dexter", "Locke", email = "dexter.locke@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2704-9720"))
   )
 Description: An interface to 'spdep' to integrate with 'sf' objects and the 'tidyverse'.
@@ -35,7 +35,7 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     sf,
     cli,

--- a/R/spacetime-methods.R
+++ b/R/spacetime-methods.R
@@ -53,7 +53,7 @@ spt_update <- function(x, ...) {
 
 #' Cast between `spacetime` and `sf` classes
 #'
-#' @param x for [sfdep::st_as_sf()] a spacetime object. For [sfdep::as_spacetime()]
+#' @param x for [sf::st_as_sf()] a spacetime object. For [sfdep::as_spacetime()]
 #'   an sf object.
 #' @param ... arguments passed to merge.
 #' @export

--- a/man/as_spacetime.Rd
+++ b/man/as_spacetime.Rd
@@ -13,7 +13,7 @@ as_spacetime(x, .loc_col, .time_col, ...)
 \method{as_spacetime}{sf}(x, .loc_col, .time_col, ...)
 }
 \arguments{
-\item{x}{for \code{\link[=st_as_sf]{st_as_sf()}} a spacetime object. For \code{\link[=as_spacetime]{as_spacetime()}}
+\item{x}{for \code{\link[sf:st_as_sf]{sf::st_as_sf()}} a spacetime object. For \code{\link[=as_spacetime]{as_spacetime()}}
 an sf object.}
 
 \item{...}{arguments passed to merge.}

--- a/man/local_jc_uni.Rd
+++ b/man/local_jc_uni.Rd
@@ -27,7 +27,7 @@ local_jc_uni(
 
 \item{alternative}{default \code{"greater"}. One of \code{"less"} or \code{"greater"}.}
 
-\item{iseed}{default NULL, used to set the seed for possible parallel RNGs}
+\item{iseed}{default NULL, used to set the seed; the output will only be reproducible if the count of CPU cores across which computation is distributed is the same}
 }
 \value{
 a \code{data.frame} with two columns \code{join_count} and \code{p_sim} and number of rows equal to the length of arguments \code{x}, \code{nb}, and \code{wt}.


### PR DESCRIPTION
@JosiahParry @DHLocke this PR just brings sfdep up to current CRAN requirements for usage of `person` and a dropped between package documentation link. With this, you can consider submitting at your earliest convenience. `spdep` with the changes that made #54 essential is about to be submitted; when it is, `sfdep` 0.2.4 will break on CRAN. Current HEAD passes with notes on R-devel; the changes in this PR remove those notes.