### PR TITLE
add ties.method arg to local_jc_uni to match forthcoming spdep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sfdep
 Title: Spatial Dependence for Simple Features
-Version: 0.2.4.9000
+Version: 0.2.5.9000
 Authors@R: c(
     person("Josiah", "Parry", email = "josiah.parry@gmail.com", role = c("aut"),
            comment = c(ORCID = "0000-0001-9910-865X")),
@@ -35,7 +35,7 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports: 
     sf,
     cli,

--- a/R/joincount-uni-impl.R
+++ b/R/joincount-uni-impl.R
@@ -6,7 +6,7 @@
 #'
 #' The local join count statistic requires a binary weights list which can be generated with `st_weights(nb, style = "B")`. Additionally, ensure that the binary variable of interest is rarely occurring in no more than half of observations.
 #'
-#' P-values are estimated using a conditional permutation approach. This creates a reference distribution from which the observed statistic is compared. For more see [Geoda Glossary](https://geodacenter.github.io/glossary.html#ppvalue).
+#' P-values are estimated using a conditional permutation approach. This creates a reference distribution from which the observed statistic is compared. For more see [Geoda Glossary](https://raw.githubusercontent.com/GeoDaCenter/GeoDaCenter.github.io/refs/heads/update-1.22/glossary.html#ppvalue).
 
 #' Calls `spdep::local_joincount_uni()`.
 #'
@@ -29,7 +29,8 @@
 #' }
 #' @returns a `data.frame` with two columns `join_count` and `p_sim` and number of rows equal to the length of arguments `x`, `nb`, and `wt`.
 local_jc_uni <- function(fx, chosen, nb, wt = st_weights(nb, style = "B"),
-                         nsim = 499, alternative = "two.sided", iseed = NULL) {
+                         nsim = 499, alternative = "two.sided",
+                         ties.method = "average", iseed = NULL) {
   listw <- recreate_listw(nb ,wt)
-  spdep::local_joincount_uni(fx, chosen, listw, alternative, nsim, iseed)
+  spdep::local_joincount_uni(fx, chosen, listw, alternative, nsim, iseed, ties.method)
 }

--- a/man/local_jc_uni.Rd
+++ b/man/local_jc_uni.Rd
@@ -11,11 +11,12 @@ local_jc_uni(
   wt = st_weights(nb, style = "B"),
   nsim = 499,
   alternative = "two.sided",
+  ties.method = "average",
   iseed = NULL
 )
 }
 \arguments{
-\item{fx}{a binary variable either numeric or logical}
+\item{fx}{a factor with two levels; use of an ordered factor is not well understood.}
 
 \item{chosen}{a scalar character containing the level of \code{fx} that should be considered the observed value (1).}
 
@@ -26,6 +27,8 @@ local_jc_uni(
 \item{nsim}{the number of conditional permutation simulations}
 
 \item{alternative}{default \code{"greater"}. One of \code{"less"} or \code{"greater"}.}
+
+\item{ties.method}{default \code{"average"} passed through to \code{rank}, can take values accepted by \code{rank}: \code{c("average", "first", "last", "random", "max", "min")}, see \code{\link{rank}}}
 
 \item{iseed}{default NULL, used to set the seed; the output will only be reproducible if the count of CPU cores across which computation is distributed is the same}
 }
@@ -39,7 +42,7 @@ than half of the time.
 \details{
 The local join count statistic requires a binary weights list which can be generated with \code{st_weights(nb, style = "B")}. Additionally, ensure that the binary variable of interest is rarely occurring in no more than half of observations.
 
-P-values are estimated using a conditional permutation approach. This creates a reference distribution from which the observed statistic is compared. For more see \href{https://geodacenter.github.io/glossary.html#ppvalue}{Geoda Glossary}.
+P-values are estimated using a conditional permutation approach. This creates a reference distribution from which the observed statistic is compared. For more see \href{https://raw.githubusercontent.com/GeoDaCenter/GeoDaCenter.github.io/refs/heads/update-1.22/glossary.html#ppvalue}{Geoda Glossary}.
 Calls \code{spdep::local_joincount_uni()}.
 }
 \examples{


### PR DESCRIPTION
spdep::local_joincount_uni is getting a ties.method argument used here:

https://github.com/r-spatial/spdep/blob/f9b712c70948ffd259c86e57f0a8c566675b4cf0/R/local-joincount-univariate.R#L104

to expose the logic used in ranking the observed value among the permutations. With categorical variables, there are often many join count ties, so exposing what to do when ties occur seems worthwhile. This PR exposes the new argument in sfdep::local_jc_uni. A release of sfdep with this PR would need to specify the forthcoming spdep version in DESCRIPTION.